### PR TITLE
Add Rugby Championship (SANZAAR) as a supported automated data source

### DIFF
--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -31,6 +31,7 @@ Wikipedia (internationals and competitions without an API feed):
 - **End-of-year Internationals**
 - **Rugby World Cup** (World Cup years only)
 - **Super Rugby**
+- **Rugby Championship** (Argentina / Australia / New Zealand / South Africa)
 - **Japan Rugby League One**
 - **Currie Cup**
 - **National Provincial Championship (NPC)**
@@ -101,8 +102,8 @@ rugby data update -t urc -t premiership -t euro-champions
 
 # Available tournament codes: urc, premiership, championship, top14, pro-d2,
 # euro-champions, euro-challenge, six-nations, mid-year-internationals,
-# end-of-year-internationals, world-cup, super-rugby, japan-league-one,
-# currie-cup, npc
+# end-of-year-internationals, world-cup, super-rugby, rugby-championship,
+# japan-league-one, currie-cup, npc
 ```
 
 ## Data Sources
@@ -136,15 +137,19 @@ rugby data update -t urc -t premiership -t euro-champions
 | end-of-year-internationals | End-of-year (autumn) internationals |
 | world-cup | Rugby World Cup (World Cup years only) |
 | super-rugby | Super Rugby |
+| rugby-championship | Rugby Championship (Argentina / Australia / New Zealand / South Africa) |
 | japan-league-one | Japan Rugby League One |
 | currie-cup | Currie Cup |
 | npc | National Provincial Championship (New Zealand) |
+
+### Known Issues
+
+- **Japan Rugby League One**: the Wikipedia page is found and rugbybox templates are detected, but they currently fail to parse into matches (0 matches saved on every run). Needs debugging against the live page - see `rugby/scrapers/six_nations.py`'s `parse_rugbybox`/`_parse_rugbybox_params`.
 
 ### Future Enhancements
 
 The system can be extended to support:
 
-- The Rugby Championship (Argentina / Australia / New Zealand / South Africa)
 - Major League Rugby (United States / Canada)
 - Rugby Europe Championship
 - Rugby Europe Super Cup - pending API availability or alternative data source

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following leagues are currently supported for automated data updates:
 - **European Rugby Champions Cup** - Premier European club competition
 - **European Rugby Challenge Cup** - Secondary European club competition
 - **Six Nations Championship**, **mid-year** and **end-of-year internationals**, and the **Rugby World Cup**
-- **Super Rugby**, **Japan Rugby League One**, **Currie Cup**, and the **National Provincial Championship (NPC)**
+- **Super Rugby**, the **Rugby Championship**, **Japan Rugby League One**, **Currie Cup**, and the **National Provincial Championship (NPC)**
 
 Use `rugby data update -t all` to update all supported leagues, or specify individual leagues with `-t <league-code>`. See [AUTOMATION.md](AUTOMATION.md) for the full list of league codes.
 

--- a/rugby/update.py
+++ b/rugby/update.py
@@ -102,6 +102,13 @@ LEAGUE_CONFIGS = {
         'filename_prefix': 'super-rugby',
         'use_calendar_year': True  # Use calendar year for season calculation
     },
+    'rugby-championship': {
+        'comp_id': None,
+        'provider': 'wikipedia',
+        'name': 'Rugby Championship',
+        'filename_prefix': 'rugby-championship',
+        'use_calendar_year': True  # Use calendar year for season calculation
+    },
     'japan-league-one': {
         'comp_id': None,
         'provider': 'wikipedia',


### PR DESCRIPTION
## Summary

- Add a `LEAGUE_CONFIGS` entry for **The Rugby Championship** (Argentina / Australia / New Zealand / South Africa) in `rugby/update.py`, the most notable missing top-tier international competition — Six Nations, the World Cup, and the internationals windows were already supported, but not its Southern Hemisphere counterpart. `rugby/scrapers/squads.py`'s own docstring already references it (`"2024 Rugby Championship squads"`), suggesting it was intended but never wired up.
- No new scraping logic needed: it reuses the same Wikipedia `{{rugbybox}}` scraper already working for Six Nations and Currie Cup. `get_wikipedia_page_title()`'s default `"{year} {championship_name}"` fallback already produces the correct page title (`"2024 Rugby Championship"`, etc.), matching the real Wikipedia article naming convention.
- Updates README.md and AUTOMATION.md's league lists/tables accordingly.

## A pre-existing issue found along the way

While checking recent `Update Match Data` workflow runs to understand why some configured leagues had no data files, I found that **Japan Rugby League One is silently broken**: every scheduled run finds the Wikipedia page and detects 6 `{{rugbybox}}` templates on it, but fails to parse any of them into matches, so it's saved zero matches for months. I've documented this as a "Known Issues" note in AUTOMATION.md rather than attempting a fix here, since debugging it requires fetching and inspecting the live Wikipedia page content, which isn't reachable from this sandboxed environment (network policy blocks `en.wikipedia.org`). Happy to pick this up in a follow-up once that's testable.

## Test plan

- [x] `python3 -m py_compile rugby/update.py rugby/commands/data.py`
- [x] Verified `LEAGUE_CONFIGS['rugby-championship']` and the derived page title (`get_wikipedia_page_title(2024, 'Rugby Championship')` → `"2024 Rugby Championship"`)
- [x] `python3 -m pytest` — all 41 existing tests pass
- [ ] Not yet verified against the live Wikipedia page (blocked by this environment's network policy) — recommend a manual `workflow_dispatch` run with `--dry-run -t rugby-championship` after merge to confirm it scrapes real matches before relying on it in the weekly schedule

Stacked on #16 (the automation cleanup PR) since it touches the same docs — based on that branch to avoid duplicate edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_015H5LjZoeDaro15e6D66bnw)_